### PR TITLE
r2 - Opening salvo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+/ResourceConfig.Terminal

--- a/ModuleResourceProvider/ExternalProcessor.cs
+++ b/ModuleResourceProvider/ExternalProcessor.cs
@@ -1,0 +1,89 @@
+﻿using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Xml.Schema;
+using CatConfig;
+using CatConfig.CclParser;
+using CatConfig.CclUnit;
+using ResourceConfig;
+namespace ModuleResourceProvider;
+
+public class ExternalProcessor : IDelayedProcessor
+{
+    private const string mod = "mod";
+
+    private readonly string[] AllowedModules;
+    private readonly Dictionary<string, Dictionary<string, Func<string[], string>>> functions = new(StringComparer.OrdinalIgnoreCase);
+
+    public ExternalProcessor(IFileSystem fs)
+    {
+        string moduleFile = fs.ReadAllText($"{Name}.{mod}");
+        var parser = Parser.FromContent("", moduleFile);
+        var modRecord = parser.ParseContent("", moduleFile) as IUnitRecord;
+        if (modRecord != null)
+        {
+            var modules = modRecord["modules"];
+            List<IUnit> units = new();
+            if (modules is IUnitArray a)
+                units = a.Elements.ToList();
+            else
+                units.Add(modules);
+
+            var allowed = units.Select(u => u as IUnitValue).Where(_ => _ != null).Select(v => v!.Value);
+
+            List<Type> externals = new();
+            foreach (var plugin in fs.GetDirectories(Name))
+                if (allowed.Contains( new DirectoryInfo(Path.GetFullPath(plugin)).Name , StringComparer.OrdinalIgnoreCase))
+                    foreach (var file in fs.GetFiles(plugin))
+                        if (Path.GetExtension(file).Equals(".dll", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var assembly = Assembly.LoadFrom(Path.GetFullPath(file));
+                            externals.AddRange(assembly.GetExportedTypes()
+                            .Where(t => allowed.Any(a => t.Name.EndsWith(a, StringComparison.OrdinalIgnoreCase) && t.Name.StartsWith("ResExtern"))));
+
+                        }
+
+
+
+            SetupFunctions(externals, functions);
+
+            Constructor.RegisterProcessor(this);
+        }
+    }
+
+    private static void SetupFunctions(IEnumerable<Type> externals, Dictionary<string, Dictionary<string, Func<string[], string>>> functions)
+    {
+        foreach (var mod in externals)
+        {
+            try
+            {
+                object? plugin = Activator.CreateInstance(mod);
+                if (plugin == null)
+                    continue;
+
+                if (!functions.TryGetValue(mod.Name, out var funcs))
+                    functions[mod.Name] = funcs = new(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var exo in mod.GetMembers().Where(m => m.CustomAttributes.Any(a => a.AttributeType == typeof(ExternAttribute))))
+                    funcs.Add(exo.Name, args => mod.GetMethod(exo.Name)?.Invoke(plugin, args)?.ToString() ?? "");
+            }
+            catch { }
+        }
+    }
+
+    public string Name => "exo";
+    public string ProtocolSchema => "res";
+
+    public IUnit ResolveDelayedUnit(int id, string name, UnitPath path)
+    {
+        string key = "ResExtern" + path[0];
+        string function = path[1];
+        var args = path[2..];
+
+        if (functions.TryGetValue(key, out var f))
+            if (f.TryGetValue(function, out var func))
+                return new UnitValue(id, func(args));
+
+        return new NoValue();
+    }
+}
+

--- a/ModuleResourceProvider/IFileSystem.cs
+++ b/ModuleResourceProvider/IFileSystem.cs
@@ -8,3 +8,4 @@ public interface IFileSystem
     IEnumerable<string> GetDirectories(string path);
     IEnumerable<string> GetDirectoryContents(string path);
 }
+

--- a/ModuleResourceProvider/ModuleProcessor.cs
+++ b/ModuleResourceProvider/ModuleProcessor.cs
@@ -1,9 +1,7 @@
-﻿using System.Reflection;
-using System.Text;
+﻿using System.Text;
 using CatConfig;
 using CatConfig.CclParser;
 using CatConfig.CclUnit;
-using Microsoft.Extensions.DependencyModel;
 namespace ModuleResourceProvider;
 public class ModuleProcessor : IDelayedProcessor
 {
@@ -65,97 +63,5 @@ public class ModuleProcessor : IDelayedProcessor
         string resource = path[0];
 
         return ResourceEngine.GetResource(id, mod, resource, path[1..]);
-    }
-}
-public class ExternalProcessor : IDelayedProcessor
-{
-    private readonly Dictionary<string, Dictionary<string, Func<string[], string>>> functions = new(StringComparer.OrdinalIgnoreCase);
-
-    public ExternalProcessor(IFileSystem fs)
-    {
-
-        foreach (var file in fs.GetFiles(Name))
-        {
-            if (Path.GetExtension(file).Equals(".dll", StringComparison.OrdinalIgnoreCase))
-            {
-                string path = Path.GetFullPath(file);
-                var assembly = Assembly.LoadFrom(path);
-            }
-        }
-
-
-
-        Constructor.RegisterProcessor(this);
-    }
-
-    public string Name => "exo";
-    public string ProtocolSchema => "res";
-
-    private void AddExternal(string name, params (string Name, Func<string[], string> Function)[] modFunctions)
-    {
-        if (!functions.TryGetValue(name, out var module))
-            functions[name] = module = new(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var f in modFunctions)
-            module.TryAdd(f.Name, f.Function);
-
-
-    }
-
-    public IUnit ResolveDelayedUnit(int id, string name, UnitPath path)
-    {
-        string key = path[0];
-        string function = path[1];
-        var args = path[2..];
-
-        if (functions.TryGetValue(key, out var f))
-            if (f.TryGetValue(function, out var func))
-                return new UnitValue(id, func(args));
-
-        return new NoValue();
-    }
-}
-
-public class Types
-{
-    private IEnumerable<Type> DiscoverAllTypes(IEnumerable<string> assemblyPrefixesToInclude)
-    {
-        var entryAssembly = Assembly.GetEntryAssembly();
-        if (entryAssembly == null)
-            return [];
-
-        var dependencyModel =
-        DependencyContext.Load(entryAssembly);
-        if (dependencyModel == null)
-            return [];
-
-        var projectReferenceAssemblies =
-        dependencyModel.RuntimeLibraries?
-        .Where(_ => _.Type.Equals("project"))
-        .Select(_ => Assembly.Load(_.Name)).ToArray()
-        ?? [];
-
-        var assemblies = (dependencyModel.RuntimeLibraries ?? [])
-        .Where(_ =>
-        _.RuntimeAssemblyGroups.Count > 0 &&
-        assemblyPrefixesToInclude.Any(assem =>
-        _.Name.StartsWith(assem)))
-        .Select(_ =>
-        {
-            try
-            {
-                return Assembly.Load(_.Name);
-
-            }
-            catch
-            {
-                return null;
-            }
-        })
-        .Where(_ => _ is not null)
-        .Distinct()
-        .ToList();
-
-        return assemblies.Concat(projectReferenceAssemblies).SelectMany(_ => _?.GetTypes() ?? []);
     }
 }

--- a/ModuleResourceProvider/ModuleResourceProvider.csproj
+++ b/ModuleResourceProvider/ModuleResourceProvider.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\depends\CatConfig\CatConfig\CatConfig.csproj" />
+    <ProjectReference Include="..\ResourceConfig\ResourceConfig.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ResourceConfig.sln
+++ b/ResourceConfig.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		revision.txt = revision.txt
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ResourceConfig.Terminal", "ResourceConfig.Terminal\ResourceConfig.Terminal.csproj", "{170FC93B-CC84-490C-91E3-195332F7E493}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{B32A9142-99A1-4A55-BF3A-D766AF7F4A33}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B32A9142-99A1-4A55-BF3A-D766AF7F4A33}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B32A9142-99A1-4A55-BF3A-D766AF7F4A33}.Release|Any CPU.Build.0 = Release|Any CPU
+		{170FC93B-CC84-490C-91E3-195332F7E493}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{170FC93B-CC84-490C-91E3-195332F7E493}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{170FC93B-CC84-490C-91E3-195332F7E493}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{170FC93B-CC84-490C-91E3-195332F7E493}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ResourceConfig/Class1.cs
+++ b/ResourceConfig/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace ResourceConfig;
-
-public class Class1
-{
-
-}

--- a/ResourceConfig/ExternAttribute.cs
+++ b/ResourceConfig/ExternAttribute.cs
@@ -1,0 +1,8 @@
+﻿namespace ResourceConfig;
+
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = false)]
+public sealed class ExternAttribute : Attribute
+{
+
+}

--- a/ResourceConfig/ResourceConfig.csproj
+++ b/ResourceConfig/ResourceConfig.csproj
@@ -4,10 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Title>Resource Config</Title>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\depends\CatConfig\CatConfig\CatConfig.csproj" />
-  </ItemGroup>
 
 </Project>

--- a/revision.txt
+++ b/revision.txt
@@ -1,2 +1,8 @@
 rev change
 r1  Initial commit
+r2  External code can be accessed using the ExternalProcessor which will look in the cudir/"exo" directory for plugins
+r2  A plugin is a directory that contains one or more library (*.dll) files which contains one or more Types with names that begin with 'ResExtern'
+r2  In these objects any method or property decorated with the 'Extern' attribute will be available in the res://exo namespace under a name matching
+r2  the Type name starting after 'ResExtern'.  Example; a class named ResExternEmployee which contains a method called 'GetHireDate' which is decorated with the 'Extern' attribute
+r2  this method would be available at: res://exo/Employee/GetHireDate/{EmployeeId}/ if (and only if) the module name (i.e. "Employee") is listed in the exo.mod config file that is read in the 
+r2  Constructor of the ExternalProcessor


### PR DESCRIPTION
r2  External code can be accessed using the ExternalProcessor which will look in the cudir/"exo" directory for plugins
r2  A plugin is a directory that contains one or more library (*.dll) files which contains one or more Types with names that begin with 'ResExtern'
r2  In these objects any method or property decorated with the 'Extern' attribute will be available in the res://exo namespace under a name matching
r2  the Type name starting after 'ResExtern'.  Example; a class named ResExternEmployee which contains a method called 'GetHireDate' which is decorated with the 'Extern' attribute
r2  this method would be available at: res://exo/Employee/GetHireDate/{EmployeeId}/ if (and only if) the module name (i.e. "Employee") is listed in the exo.mod config file that is read in the 
r2  Constructor of the ExternalProcessor
